### PR TITLE
Chaosiq workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ journal.json
 
 test.txt
 test.json
+
+# Pycharm IDE
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 [Unreleased]: https://github.com/chaosiq/chaosiq-cloud/compare/0.5.0...HEAD
 
+### Added
+
+- Generate a `".chaosiq"` workspace file for registering experiment IDs
+  related to their local file names. [#30][30]
+
 ### Changed
 
 - Adapted to use the organization/team schema of the remote API [#27][27]
 - Fixed: features were reset to default value when updating settings [#31][31]
 
 [27]: https://github.com/chaosiq/chaosiq-cloud/issues/27
+[30]: https://github.com/chaosiq/chaosiq-cloud/issues/30
 [31]: https://github.com/chaosiq/chaosiq-cloud/issues/31
 
 ## [0.5.0][] - 2019-11-26

--- a/chaoscloud/api/experiment.py
+++ b/chaoscloud/api/experiment.py
@@ -6,6 +6,7 @@ from logzero import logger
 import requests
 
 from . import urls
+from ..extension import remove_sensitive_extension_values
 
 __all__ = ["publish_experiment"]
 
@@ -17,9 +18,11 @@ def publish_experiment(session: requests.Session,
     """
     try:
         experiment_url = urls.experiment(session.base_url)
-        r = session.post(experiment_url, json={
-            "experiment": experiment
-        })
+        with remove_sensitive_extension_values(
+                experiment, ["experiment_path"]):
+            r = session.post(experiment_url, json={
+                "experiment": experiment
+            })
     except Exception:
         logger.warning(
             "Failed to publish experiment to '{}'".format(experiment_url))

--- a/chaoscloud/cli.py
+++ b/chaoscloud/cli.py
@@ -20,9 +20,10 @@ from .api.ssl import verify_ssl_certificate
 from .api.team import request_teams
 from .api import urls
 from .settings import set_settings, get_endpoint_url, get_orgs, \
-    verify_tls_certs, enable_safeguards, enable_publishing, \
-    disable_safeguards, disable_publishing, get_verify_tls, get_auth_token, \
-    get_default_org
+    verify_tls_certs, \
+    get_verify_tls, get_auth_token, \
+    get_default_org, \
+    enable_feature, disable_feature, FEATURES
 
 __all__ = ["signin", "publish", "org", "enable", "disable", "team"]
 
@@ -155,7 +156,7 @@ def publish(ctx: click.Context, journal: str):
 
 
 @cli.command(help="Enable a ChaosIQ feature")
-@click.argument('feature', type=click.Choice(['safeguards', 'publish']))
+@click.argument('feature', type=click.Choice(FEATURES))
 @click.pass_context
 def enable(ctx: click.Context, feature: str):
     """
@@ -165,15 +166,12 @@ def enable(ctx: click.Context, feature: str):
     """
     settings_path = ctx.obj["settings_path"]
     settings = load_settings(settings_path)
-    if feature == "safeguards":
-        enable_safeguards(settings)
-    elif feature == "publish":
-        enable_publishing(settings)
+    enable_feature(settings, feature)
     save_settings(settings, settings_path)
 
 
 @cli.command(help="Disable a ChaosIQ feature")
-@click.argument('feature', type=click.Choice(['safeguards', 'publish']))
+@click.argument('feature', type=click.Choice(FEATURES))
 @click.pass_context
 def disable(ctx: click.Context, feature: str):
     """
@@ -183,10 +181,7 @@ def disable(ctx: click.Context, feature: str):
     """
     settings_path = ctx.obj["settings_path"]
     settings = load_settings(settings_path)
-    if feature == "safeguards":
-        disable_safeguards(settings)
-    elif feature == "publish":
-        disable_publishing(settings)
+    disable_feature(settings, feature)
     save_settings(settings, settings_path)
 
 

--- a/chaoscloud/exceptions.py
+++ b/chaoscloud/exceptions.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from chaoslib.exceptions import ChaosException
+
+
+__all__ = ["WorkspaceException"]
+
+
+class WorkspaceException(ChaosException):
+    pass

--- a/chaoscloud/extension.py
+++ b/chaoscloud/extension.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from typing import Any, List
+from contextlib import contextmanager
+
+from chaoslib.types import Experiment
+
+__all__ = ["get_extension_value", "set_extension_value",
+           "del_extension_value", "remove_sensitive_extension_values"]
+
+
+def get_extension_value(experiment: Experiment,
+                        key: str, default: Any = None):
+    extensions = experiment.setdefault("extensions", [])
+    for extension in extensions:
+        ext_name = extension.get("name")
+        if ext_name == "chaosiq":
+            return extension.get(key, default)
+
+
+def set_extension_value(experiment: Experiment, key: str, value: Any):
+    extensions = experiment.setdefault("extensions", [])
+    for extension in extensions:
+        ext_name = extension.get("name")
+        if ext_name == "chaosiq":
+            extension[key] = str(value)
+            break
+    else:
+        extensions.append({
+            "name": "chaosiq",
+            key: value
+        })
+
+
+def del_extension_value(experiment: Experiment, key: str, silent: bool = True):
+    extensions = experiment.setdefault("extensions", [])
+    for extension in extensions:
+        ext_name = extension.get("name")
+        if ext_name == "chaosiq":
+            try:
+                del extension[key]
+            except KeyError:
+                if not silent:
+                    raise
+
+
+class SensitiveManager:
+    """
+    This class provides utility functions to remove & restore
+    sensitive values from the experiment extension
+    """
+    def __init__(self):
+        self.sensitive = {}
+
+    def remove_sensitive_values(self, experiment: Experiment,
+                                keys: List[str] = None):
+        if keys is None:
+            return
+
+        for key in keys:
+            self.sensitive[key] = get_extension_value(experiment, key)
+            del_extension_value(experiment, key, silent=True)
+
+    def restore_sensitive_values(self, experiment: Experiment,
+                                 keys: List[str] = None):
+        if keys is None:
+            return
+
+        for key in keys:
+            set_extension_value(experiment, key, self.sensitive[key])
+
+
+@contextmanager
+def remove_sensitive_extension_values(experiment: Experiment,
+                                      keys: List[str] = None):
+    """
+    context manager for a block that needs to have experiment available
+    without sensitive data.
+
+    it removes the sensitive when entering the with block, then
+    restores them when leaving it.
+    """
+    try:
+        sm = SensitiveManager()
+        sm.remove_sensitive_values(experiment, keys)
+        yield
+    finally:
+        sm.restore_sensitive_values(experiment, keys)

--- a/chaoscloud/settings.py
+++ b/chaoscloud/settings.py
@@ -5,9 +5,12 @@ from urllib.parse import urlparse
 
 from chaoslib.types import Control, Settings
 
-__all__ = ["set_settings", "get_endpoint_url", "disable_publishing",
-           "enable_publishing", "disable_safeguards", "enable_safeguards",
-           "is_feature_enabled", "get_verify_tls", "get_auth_token"]
+__all__ = ["set_settings", "get_endpoint_url",
+           "is_feature_enabled", "get_verify_tls", "get_auth_token",
+           "enable_feature", "disable_feature", "FEATURES"]
+
+
+FEATURES = ['publish', 'safeguards', 'workspace']
 
 
 def set_settings(url: str, token: str, verify_tls: bool,
@@ -30,7 +33,7 @@ def set_settings(url: str, token: str, verify_tls: bool,
     set_default_org(settings, default_org)
 
     features = control.setdefault('features', {})
-    for feature in ['publish', 'safeguards']:
+    for feature in FEATURES:
         features.setdefault(feature, 'on')
 
     control.update({
@@ -46,24 +49,26 @@ def set_settings(url: str, token: str, verify_tls: bool,
     })
 
 
-def disable_publishing(settings: Settings):
+def disable_feature(settings: Settings, feature: str):
+    if feature not in FEATURES:
+        return
+
     control = get_control(settings)
-    control.setdefault('features', {})['publish'] = "off"
+    if not control:
+        return
+
+    control.setdefault('features', {})[feature] = "off"
 
 
-def enable_publishing(settings: Settings):
+def enable_feature(settings: Settings, feature: str):
+    if feature not in FEATURES:
+        return
+
     control = get_control(settings)
-    control.setdefault('features', {})['publish'] = "on"
+    if not control:
+        return
 
-
-def disable_safeguards(settings: Settings):
-    control = get_control(settings)
-    control.setdefault('features', {})['safeguards'] = "off"
-
-
-def enable_safeguards(settings: Settings):
-    control = get_control(settings)
-    control.setdefault('features', {})['safeguards'] = "on"
+    control.setdefault('features', {})[feature] = "on"
 
 
 def get_endpoint_url(settings: Settings,

--- a/chaoscloud/types.py
+++ b/chaoscloud/types.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Dict, List
+
+__all__ = ["Organization", "Organizations", "WorkspaceData"]
+
+
+Organization = Dict[str, Any]
+Organizations = List[Organization]
+
+WorkspaceData = Dict[str, Any]

--- a/chaoscloud/workspace.py
+++ b/chaoscloud/workspace.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+import copy
+import io
+import os
+import yaml
+from typing import Dict, Any, Optional, NoReturn
+
+from logzero import logger
+
+from chaoslib.types import Experiment
+from .exceptions import WorkspaceException
+from .types import Organization, Organizations, WorkspaceData
+from .extension import get_extension_value
+
+__all__ = ["initialize_workspace_path",
+           "load_workspace", "save_workspace",
+           "register_experiment_to_workspace",
+           "get_experiment_metadata_from_workspace"]
+
+
+WORKSPACE_FILENAME = ".chaosiq"
+
+workspace_path = None
+workspace_metadata = {}
+
+# the workspace metadata dict contains the following structure:
+# - experiments:
+#   - <organization ID>:
+#     - <experiment file name (with extension)>:
+#       - <experiment ID>: <value>
+
+
+def initialize_workspace_path(experiment_path: str):
+    """
+    Given an experiment path on the local file system,
+    generates the related ChaosIQ workspace file, and
+    keeps a reference to this internal file
+    """
+    set_workspace_path(
+        os.path.join(os.path.dirname(experiment_path), WORKSPACE_FILENAME))
+
+
+def set_workspace_path(path: str):
+    """
+    sets the path to the global variable
+    """
+    global workspace_path
+    workspace_path = path
+
+
+def get_workspace_path() -> str:
+    """
+    Returns the currently set workspace path
+    """
+    return workspace_path
+
+
+def get_loaded_workspace_data() -> WorkspaceData:
+    """
+    Return the current workspace's data loaded from the hidden file
+    on the file system alongside the experiment
+    """
+    return copy.deepcopy(workspace_metadata)
+
+
+def set_workspace_data(data: WorkspaceData) -> NoReturn:
+    """
+    Sets new data as the global available workspace
+    """
+    global workspace_metadata
+    workspace_metadata = data
+
+
+def reset_workspace() -> NoReturn:
+    set_workspace_data({})
+
+
+def load_workspace(path: str = None) -> NoReturn:
+    """
+    Parse the given workspace's internal files from `path` and load them.
+    """
+    path = path or workspace_path
+
+    if not os.path.exists(path):
+        logger.debug(
+            "The ChaosIQ workspace file could not be found at "
+            "'{}'.".format(path))
+        return
+
+    with io.open(path) as f:
+        try:
+            set_workspace_data(yaml.safe_load(f))
+        except yaml.YAMLError as ye:
+            raise WorkspaceException(
+                "Failed parsing workspace YAML file {}: {}".format(
+                    path, str(ye)))
+
+
+def save_workspace(path: str = None) -> NoReturn:
+    """
+    Save the experiments context into the internal workspace file
+    on the local file system
+    """
+    path = path or workspace_path
+    if path is None:
+        return
+
+    logger.debug("Saving workspace at {}".format(path))
+    try:
+        with io.open(path, 'w') as outfile:
+            yaml.dump(workspace_metadata, outfile, default_flow_style=False)
+    except (yaml.YAMLError, OSError, IOError) as error:
+        raise WorkspaceException(
+            "Failed saving workspace YAML file to {}: {}".format(
+                path, str(error)))
+
+
+def register_experiment_to_workspace(
+        experiment: Experiment,
+        organizations: Organizations,
+        experiment_path: str = None) -> NoReturn:
+    """
+    Register the link between the experiment ID and the experiment path
+    into the workspace related to the experiment's location
+    on the local file system.
+
+    This link experiment path -> experiment ID allows to associate
+    several executions with the same experiment on the console.
+    The link is registered for the current/active organization ID.
+    """
+    if experiment_path is None:
+        experiment_path = get_experiment_path(experiment)
+
+    if not experiment_path:
+        return
+
+    if not os.path.exists(experiment_path):
+        return
+
+    experiment_id = get_experiment_id(experiment)
+    experiment_name = os.path.basename(experiment_path)
+    org = get_default_org(organizations)
+    organization_id = org["id"]
+    team = get_default_team(org)
+    team_id = team["id"]
+
+    logger.debug(
+        "Registering experiment '{name}' with ID '{id}' "
+        "for organization '{org}' and team '{team}'".format(
+            name=experiment_name, id=experiment_id,
+            org=organization_id, team=team_id))
+
+    meta = workspace_metadata.\
+        setdefault("experiments", {}).\
+        setdefault(organization_id, {}). \
+        setdefault(team_id, {}). \
+        setdefault(experiment_name, {})
+    meta["experiment_id"] = experiment_id
+
+
+def get_experiment_metadata_from_workspace(
+        experiment: Experiment,
+        organizations: Organizations,
+        experiment_path: str = None) -> Optional[Dict[str, Any]]:
+    """
+    For the loaded workspace, check whether the experiment ID exists
+    for the experiment path related to the given organization
+
+    If the experiment path is not recognized in the workspace,
+    this is returning None as response ie unknown experiment
+    (probably a new experiment file, or maybe path has changed)
+    """
+    if experiment_path is None:
+        experiment_path = get_experiment_path(experiment)
+
+    if not experiment_path:
+        return
+
+    organization_id = get_default_org_id(organizations)
+    team_id = get_default_team_id(get_default_org(organizations))
+    experiment_name = os.path.basename(experiment_path)
+    return workspace_metadata.\
+        get("experiments", {}).\
+        get(organization_id, {}). \
+        get(team_id, {}). \
+        get(experiment_name, {})
+
+
+###############################################################################
+# Internals
+###############################################################################
+def get_experiment_path(experiment: Experiment) -> Optional[str]:
+    return get_extension_value(experiment, "experiment_path")
+
+
+def get_experiment_source(experiment: Experiment) -> Optional[str]:
+    return get_extension_value(experiment, "source")
+
+
+def get_experiment_id(experiment: Experiment) -> str:
+    return get_extension_value(experiment, "experiment_id")
+
+
+def get_default_org(organizations: Organizations) -> Organization:
+    for org in organizations:
+        if org.get('default') is True:
+            return org
+
+
+def get_default_org_id(organizations: Organizations) -> Optional[str]:
+    org = get_default_org(organizations)
+    if org:
+        return org["id"]
+
+
+def get_default_team(org: Dict[str, str]) -> Optional[Dict[str, Any]]:
+    teams = org.get('teams', [])
+    for team in teams:
+        if team['default']:
+            return team
+
+
+def get_default_team_id(org: Organization) -> Optional[str]:
+    team = get_default_team(org)
+    if team:
+        return team["id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,8 @@ def settings() -> Dict[str, Any]:
                 "chaosiq-cloud": {
                     "features": {
                         "publish": 'on',
-                        "safeguards": 'on'
+                        "safeguards": 'on',
+                        "workspace": 'on'
                     }
                 }
             }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from chaoscloud.settings import get_endpoint_url, set_settings
+from chaoscloud.settings import get_endpoint_url, set_settings, \
+    FEATURES, enable_feature, disable_feature, is_feature_enabled
 
 
 def test_adding_new_chaosiq_settings(default_org, default_team):
@@ -156,3 +157,33 @@ def test_get_default_when_none_found():
         }
     }
     assert get_endpoint_url(settings) == 'https://console.chaosiq.io'
+
+
+def test_enable_disable_valid_feature(default_org):
+    settings = {
+        'controls': {
+            'chaosiq-cloud': {
+                'features': {}
+            }
+        }
+    }
+    feature = FEATURES[0]
+
+    enable_feature(settings, feature)
+    assert settings['controls']['chaosiq-cloud']['features'][feature] == 'on'
+    assert is_feature_enabled(settings, feature)
+
+    disable_feature(settings, feature)
+    assert settings['controls']['chaosiq-cloud']['features'][feature] == 'off'
+    assert not is_feature_enabled(settings, feature)
+
+
+def test_enable_disable_invalid_feature(default_org):
+    settings = {}
+    feature = "invalid"
+
+    enable_feature(settings, feature)
+    assert settings == {}
+
+    disable_feature(settings, feature)
+    assert settings == {}

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+import os
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
+
+from chaoscloud.workspace import workspace_metadata, \
+    set_workspace_path, get_workspace_path, initialize_workspace_path, \
+    get_loaded_workspace_data, set_workspace_data, reset_workspace, \
+    load_workspace, save_workspace, register_experiment_to_workspace, \
+    get_experiment_metadata_from_workspace
+from chaoscloud.exceptions import WorkspaceException
+
+
+EMPTY_VALUES = (None, '', [], (), {})
+
+
+def test_set_custom_workspace_path():
+    assert get_workspace_path() is None
+
+    tests_folder = os.path.dirname(__name__)
+
+    p = os.path.join(tests_folder, '.dummy')
+    set_workspace_path(p)
+    assert get_workspace_path() == p
+
+    # reset workspace path at end of test
+    set_workspace_path(None)
+
+
+def test_initialize_experiments_workspace_path():
+    assert get_workspace_path() is None
+
+    tests_folder = os.path.dirname(__name__)
+
+    exp_path = os.path.join(tests_folder, 'dummy-experiment.json')
+    ws_path = os.path.join(tests_folder, ".chaosiq")
+
+    initialize_workspace_path(exp_path)
+    assert get_workspace_path() == ws_path
+
+    # reset workspace path at end of test
+    set_workspace_path(None)
+
+
+def test_set_workspace_data():
+    data = {"dummy": "data"}
+    set_workspace_data(data)
+    assert get_loaded_workspace_data() == data
+
+    # clean up
+    reset_workspace()
+
+
+def test_reset_workspace_data():
+    set_workspace_data({"dummy": "data"})
+    assert get_loaded_workspace_data() not in EMPTY_VALUES
+
+    reset_workspace()
+    assert get_loaded_workspace_data() in EMPTY_VALUES
+
+
+def test_get_loaded_workspace_data_cannot_be_mutated():
+    set_workspace_data({"dummy": "data"})
+
+    data1 = get_loaded_workspace_data()
+    data2 = get_loaded_workspace_data()
+    assert data1 == data2
+
+    # mutate one of the data dict and check the other one is not
+    # neither the global workspace variable
+    data1["extra"] = "value"
+    assert data1 != data2
+    assert data1 != workspace_metadata
+    assert data1 != get_loaded_workspace_data()
+    assert data2 == get_loaded_workspace_data()
+
+    # clean up
+    reset_workspace()
+
+
+def test_load_workspace_invalid_path():
+    load_workspace('/tmp/invalid')
+    assert get_loaded_workspace_data() in EMPTY_VALUES
+
+
+def test_load_workspace_invalid_yaml():
+    with NamedTemporaryFile(suffix="yaml", mode="w") as workspace:
+        workspace.write('- "invalid" "yaml"')
+        workspace.seek(0)
+
+        try:
+            load_workspace(workspace.name)
+        except WorkspaceException:
+            assert True, "WorkspaceException has been raised."
+        else:
+            assert False, "WorkspaceException has NOT been raised."
+
+
+def test_load_workspace():
+    with NamedTemporaryFile(suffix="yaml", mode='w') as workspace:
+        workspace.write("experiments:\n")
+        workspace.write("  chaosiq:\n")
+        workspace.write("    test:\n")
+        workspace.write("      dummy.json:\n")
+        workspace.write("        experiment_id: azerty123456\n")
+        workspace.seek(0)
+
+        load_workspace(workspace.name)
+        data = get_loaded_workspace_data()
+        assert data == {
+            "experiments": {
+                "chaosiq": {
+                    "test": {
+                        "dummy.json": {
+                            "experiment_id": "azerty123456"
+                        }
+                    }
+                }
+            }
+        }
+
+    # clean up
+    reset_workspace()
+
+
+def test_save_workspace():
+    set_workspace_data({"experiments": {}})
+
+    with NamedTemporaryFile(suffix="yaml", mode='w') as workspace:
+        save_workspace(workspace.name)
+
+    # clean up
+    reset_workspace()
+
+
+def test_save_workspace_non_writable_file():
+    with NamedTemporaryFile(suffix="yaml") as workspace:
+        os.chmod(workspace.name, 0o500)
+
+        try:
+            save_workspace(workspace.name)
+        except WorkspaceException:
+            assert True, "WorkspaceException has been raised."
+        else:
+            assert False, "WorkspaceException has NOT been raised."
+
+
+def test_register_experiment_without_path():
+    experiment = {
+        "title": "hello"
+    }
+    register_experiment_to_workspace(experiment, [])
+    assert get_loaded_workspace_data() == {}
+
+
+def test_register_experiment_path_does_not_exist():
+    experiment = {
+        "title": "hello"
+    }
+    register_experiment_to_workspace(experiment, [], '/tmp/experiment.json')
+    assert get_loaded_workspace_data() == {}
+
+
+@patch("os.path.exists")
+def test_register_experiment(mock_exists, organizations,
+                             default_org_id, default_team_id):
+    mock_exists.return_value = True
+
+    experiment = {
+        "title": "hello",
+        "extensions": [
+            {
+                "name": "chaosiq",
+                "experiment_id": "azerty123456",
+                "experiment_path": "/tmp/experiment.json"
+            }
+        ]
+    }
+
+    register_experiment_to_workspace(experiment, organizations)
+    assert get_loaded_workspace_data() != {}
+    data = get_loaded_workspace_data()
+    assert "experiment.json" in \
+           data["experiments"][default_org_id][default_team_id]
+
+    # clean up
+    reset_workspace()
+
+
+@patch("os.path.exists")
+def test_fetch_experiment_metadata(mock_exists, organizations,
+                                   default_org_id, default_team_id):
+    mock_exists.return_value = True
+
+    set_workspace_data({
+        "experiments": {
+            default_org_id: {
+                default_team_id: {
+                    "experiment.json": {
+                        "experiment_id": "azerty123456"
+                    }
+                }
+            }
+        }
+    })
+
+    experiment = {
+        "title": "hello"
+    }
+    experiment_meta = get_experiment_metadata_from_workspace(
+        experiment, organizations, experiment_path="/tmp/experiment.json")
+    assert experiment_meta["experiment_id"] == "azerty123456"
+
+    # clean up
+    reset_workspace()


### PR DESCRIPTION
This is an initial version to be able to link experiment file names, from a local folder, with an experiment ID that is published on the console.

This is lacking unit tests for now, as it needs review with the workflow & behavior. 

One issue was to pass the local experiment path from the after-loading-experiment control to the configure-control function, but not publishing this to the backend API. To bad we could not use the existing source attribute on the extension and needed an extra one. 