### PR TITLE
Add --no-verify-tls flag to chaos validate to disable TLS certificate…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaosiq/chaosiq-cloud/compare/0.10.0...HEAD
 
+### Added
+
+-   New `--no-verify-tls` flag to `chaos verify` command
+
 ## [0.10.0][] - 2020-03-05
 
 [0.10.0]: https://github.com/chaosiq/chaosiq-cloud/compare/0.9.5...0.10.0

--- a/chaoscloud/cli.py
+++ b/chaoscloud/cli.py
@@ -186,11 +186,14 @@ def disable(ctx: click.Context, feature: str):
               help='Run the verification without executing activities.')
 @click.option('--no-validation', is_flag=True,
               help='Do not validate the verification before running.')
+@click.option('--no-verify-tls', is_flag=True,
+              help='Do not verify TLS certificate.')
 @click.argument('source')
 @click.pass_context
 def verify(ctx: click.Context, source: str,
            journal_path: str = "./journal.json", dry: bool = False,
-           no_validation: bool = False, no_exit: bool = False):
+           no_validation: bool = False, no_exit: bool = False,
+           no_verify_tls: bool = False):
     """Run the verification loaded from SOURCE, either a local file or a
        HTTP resource. SOURCE can be formatted as JSON or YAML."""
 
@@ -202,7 +205,7 @@ def verify(ctx: click.Context, source: str,
             ctx.exit(1)
 
         verification = load_experiment(
-            click.format_filename(source), settings)
+            source, settings, verify_tls=not no_verify_tls)
     except InvalidSource as x:
         logger.error(str(x))
         logger.debug(x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-chaostoolkit-lib~=1.7
-chaostoolkit~=1.3
+chaostoolkit-lib~=1.9
+chaostoolkit~=1.4
 click~=7.0
 logzero~=1.5
 requests~=2.21


### PR DESCRIPTION
… validation, when using experiment URL over self-signed endpoint

Signed-off-by: David Martin <david@chaosiq.io>